### PR TITLE
Add line_status tool to query TfL line status via MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,73 @@
+# AGENTS.md — TFL MCP Server
+
+## Project Purpose
+
+This is an **MCP (Model Context Protocol) server** that wraps the **TfL (Transport for London) Unified API**, making live London transport data accessible to AI assistants such as Claude.
+
+The server exposes TfL capabilities as MCP tools so an assistant can answer questions like:
+- "Is the Central line running normally?"
+- "When is the next bus from stop ABC?"
+- "How do I get from King's Cross to Canary Wharf right now?"
+- "Are there any disruptions on the Elizabeth line?"
+
+## TfL API
+
+- Base URL: `https://api.tfl.gov.uk`
+- Docs / Swagger: `https://api.tfl.gov.uk/swagger/ui/index.html`
+- Key registration: `https://api-portal.tfl.gov.uk/`
+- API key is passed as query param `app_key=<key>` or via `TFL_APP_KEY` env var
+- No key required for low-volume usage; key raises rate limits
+
+Key TfL API areas (each maps to one or more MCP tools):
+
+| TfL API area | Example endpoint | Planned tool |
+|---|---|---|
+| Line status | `GET /Line/{ids}/Status` | `line_status` |
+| Stop arrivals | `GET /StopPoint/{id}/Arrivals` | `arrivals` |
+| Stop search | `GET /StopPoint/Search/{query}` | `stop_search` |
+| Journey planner | `GET /Journey/JourneyResults/{from}/to/{to}` | `journey` |
+| Disruptions | `GET /Line/Mode/{modes}/Disruption` | `disruptions` |
+| Bike points | `GET /BikePoint` | `bike_points` |
+
+## Architecture
+
+- **Language:** Java 25
+- **Build:** Gradle 9.4.1 (Kotlin DSL)
+- **HTTP server:** Jetty 12 (EE10)
+- **MCP transport:** SSE (Server-Sent Events) via `HttpServletSseServerTransportProvider`
+- **MCP SDK:** `io.modelcontextprotocol.sdk:mcp:1.1.0`
+- **Main class:** `com.aon.tfl.App`
+- **Tests:** JUnit 5 integration tests — spin up the full server on a random port and connect via an MCP client
+
+## Development Workflow
+
+We use **red-green TDD**:
+1. Write a failing test in `AppTest.java` that covers the new tool
+2. Implement the tool in `App.java` (minimal code to pass the test)
+3. Refactor if needed
+4. Commit and push
+
+## Key Constraints
+
+- Keep `App.java` simple; extract service/helper classes only when complexity justifies it
+- Integration tests must pass: `./gradlew test`
+- The TfL API key is optional for tests — stub or use a real key via `TFL_APP_KEY` env var
+- All HTTP calls to TfL should respect the `TFL_APP_KEY` env var if set
+- Tests use WireMock (`wiremock-jetty12:3.13.2`) to stub TfL API — no real network calls needed
+
+## Working Branch
+
+`claude/tdd-feature-development-XKlcZ`
+
+## Feature Backlog
+
+Pick up from the first unchecked item and follow the red-green TDD workflow above.
+
+- [x] `line_status` — current status of one or more lines (`GET /Line/{ids}/Status`)
+- [ ] `arrivals` — live arrivals at a stop (`GET /StopPoint/{id}/Arrivals`)
+- [ ] `stop_search` — search for stops by name/query (`GET /StopPoint/Search/{query}`)
+- [ ] `disruptions` — current disruptions by mode (`GET /Line/Mode/{modes}/Disruption`)
+- [ ] `journey` — plan a journey between two points (`GET /Journey/JourneyResults/{from}/to/{to}`)
+- [ ] `bike_points` — list Santander Cycles docking stations (`GET /BikePoint`)
+- [ ] Remove placeholder `echo` and `greet` tools once real tools are in place
+- [ ] Update README tools table to reflect all implemented tools

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,28 +1,48 @@
-# TFL
+# TFL MCP Server
 
 [![Build](https://github.com/oneill9/tfl/actions/workflows/build.yml/badge.svg)](https://github.com/oneill9/tfl/actions/workflows/build.yml)
 
-MCP (Model Context Protocol) server built with Java 25, Gradle 9.4.1, and Jetty 12.
+An MCP (Model Context Protocol) server that exposes the [TfL (Transport for London) Unified API](https://api.tfl.gov.uk/) as tools, allowing AI assistants like Claude to query live London transport data.
 
-Uses the [MCP Java SDK](https://github.com/modelcontextprotocol/java-sdk) v1.1.0 with SSE transport.
+Built with Java 25, Gradle 9.4.1, Jetty 12, and the [MCP Java SDK](https://github.com/modelcontextprotocol/java-sdk) v1.1.0 (SSE transport).
 
 ## Tools
 
 | Tool | Description |
 |------|-------------|
-| `echo` | Echoes back the provided text |
-| `greet` | Returns a greeting for the given name |
+| `echo` | Echoes back the provided text (dev/debug) |
+| `greet` | Returns a greeting for the given name (dev/debug) |
+
+> More tools covering TfL line status, arrivals, stop lookup, journey planning, and disruptions are planned.
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|----------------------|---------|-------------|
+| `PORT` | `3001` | HTTP port the server listens on |
+| `TFL_APP_KEY` | *(none)* | TfL API key — register at [api-portal.tfl.gov.uk](https://api-portal.tfl.gov.uk/) |
+
+Requests work without an API key but are rate-limited. An app key raises the limit significantly.
 
 ## Running
 
 ```sh
-./gradlew run
+TFL_APP_KEY=your_key_here ./gradlew run
 ```
 
-Server starts on `http://localhost:3001` by default. Override with `PORT` env var.
+Server starts on `http://localhost:3001` by default.
+
+SSE endpoint: `/sse`
+Message endpoint: `/mcp/message`
 
 ## Testing
 
 ```sh
 ./gradlew test
 ```
+
+## TfL API Reference
+
+- Unified API: <https://api.tfl.gov.uk/>
+- API Portal / Key Registration: <https://api-portal.tfl.gov.uk/>
+- Swagger UI: <https://api.tfl.gov.uk/swagger/ui/index.html>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,11 +20,15 @@ dependencies {
     implementation("org.eclipse.jetty:jetty-server:12.0.18")
     implementation("org.eclipse.jetty.ee10:jetty-ee10-servlet:12.0.18")
 
+    // JSON parsing for TfL API responses
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.18.3")
+
     // Logging
     implementation("ch.qos.logback:logback-classic:1.5.16")
 
     // Testing
     testImplementation("org.junit.jupiter:junit-jupiter:5.12.1")
+    testImplementation("org.wiremock:wiremock-jetty12:3.13.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/java/com/aon/tfl/App.java
+++ b/src/main/java/com/aon/tfl/App.java
@@ -10,17 +10,35 @@ import org.eclipse.jetty.ee10.servlet.ServletHolder;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public class App {
 
+    private static final String TFL_APP_KEY = System.getenv("TFL_APP_KEY");
+    private static final HttpClient HTTP = HttpClient.newHttpClient();
+    private static final ObjectMapper JSON = new ObjectMapper();
+
     private final Server jetty;
     private final McpSyncServer mcpServer;
     private final int port;
+    private final String tflBase;
 
     public App(int port) throws Exception {
+        this(port, "https://api.tfl.gov.uk");
+    }
+
+    public App(int port, String tflBase) throws Exception {
         this.port = port;
+        this.tflBase = tflBase;
 
         var transportProvider = HttpServletSseServerTransportProvider.builder()
                 .messageEndpoint("/mcp/message")
@@ -58,6 +76,29 @@ public class App {
                         (exchange, request) -> McpSchema.CallToolResult.builder()
                                 .addTextContent("Hello, " + request.arguments().get("name") + "! Welcome to TFL.")
                                 .build())
+                .toolCall(
+                        McpSchema.Tool.builder()
+                                .name("line_status")
+                                .description("Get the current status of one or more TfL lines (e.g. central, victoria, jubilee)")
+                                .inputSchema(new McpSchema.JsonSchema(
+                                        "object",
+                                        Map.of("lines", Map.of("type", "string", "description", "Comma-separated line IDs, e.g. central,victoria")),
+                                        List.of("lines"),
+                                        null, null, null))
+                                .build(),
+                        (exchange, request) -> {
+                            String lines = request.arguments().get("lines").toString();
+                            try {
+                                return McpSchema.CallToolResult.builder()
+                                        .addTextContent(fetchLineStatus(lines))
+                                        .build();
+                            } catch (Exception e) {
+                                return McpSchema.CallToolResult.builder()
+                                        .addTextContent("Error fetching line status: " + e.getMessage())
+                                        .isError(true)
+                                        .build();
+                            }
+                        })
                 .build();
 
         jetty = new Server();
@@ -85,6 +126,29 @@ public class App {
     public void stop() throws Exception {
         mcpServer.closeGracefully();
         jetty.stop();
+    }
+
+    private String fetchLineStatus(String lines) throws Exception {
+        String url = tflBase + "/Line/" + lines + "/Status";
+        if (TFL_APP_KEY != null && !TFL_APP_KEY.isBlank()) {
+            url += "?app_key=" + TFL_APP_KEY;
+        }
+        var request = HttpRequest.newBuilder(URI.create(url)).GET().build();
+        var response = HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+        JsonNode root = JSON.readTree(response.body());
+
+        var sb = new StringBuilder();
+        for (JsonNode line : root) {
+            String name = line.path("name").asText();
+            var statuses = new ArrayList<String>();
+            for (JsonNode status : line.path("lineStatuses")) {
+                String desc = status.path("statusSeverityDescription").asText();
+                String reason = status.path("reason").asText("");
+                statuses.add(reason.isBlank() ? desc : desc + " — " + reason);
+            }
+            sb.append(name).append(": ").append(String.join("; ", statuses)).append("\n");
+        }
+        return sb.toString().trim();
     }
 
     public static void main(String[] args) throws Exception {

--- a/src/test/java/com/aon/tfl/AppTest.java
+++ b/src/test/java/com/aon/tfl/AppTest.java
@@ -1,5 +1,6 @@
 package com.aon.tfl;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
@@ -12,19 +13,41 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.Map;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.junit.jupiter.api.Assertions.*;
 
 class AppTest {
 
+    static WireMockServer wireMock;
     static App app;
     static McpSyncClient client;
 
     @BeforeAll
     static void setUp() throws Exception {
-        app = new App(0); // port 0 = random available port
+        wireMock = new WireMockServer(wireMockConfig().dynamicPort());
+        wireMock.start();
+
+        wireMock.stubFor(get(urlPathMatching("/Line/central/Status"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                [{"id":"central","name":"Central","lineStatuses":[{"statusSeverityDescription":"Good Service","reason":""}]}]
+                                """)));
+
+        wireMock.stubFor(get(urlPathMatching("/Line/central,victoria/Status"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                [
+                                  {"id":"central","name":"Central","lineStatuses":[{"statusSeverityDescription":"Good Service","reason":""}]},
+                                  {"id":"victoria","name":"Victoria","lineStatuses":[{"statusSeverityDescription":"Minor Delays","reason":"Earlier signal failure"}]}
+                                ]
+                                """)));
+
+        app = new App(0, "http://localhost:" + wireMock.port());
         app.start();
 
-        // Get the actual port Jetty chose
         int port = ((org.eclipse.jetty.server.ServerConnector)
                 app.getJetty().getConnectors()[0]).getLocalPort();
 
@@ -43,6 +66,7 @@ class AppTest {
     static void tearDown() throws Exception {
         if (client != null) client.close();
         if (app != null) app.stop();
+        if (wireMock != null) wireMock.stop();
     }
 
     @Test
@@ -59,12 +83,11 @@ class AppTest {
     }
 
     @Test
-    void listToolsReturnsEchoAndGreet() {
+    void listToolsContainsEchoAndGreet() {
         var result = client.listTools();
         var names = result.tools().stream().map(McpSchema.Tool::name).toList();
         assertTrue(names.contains("echo"), "Should contain echo tool");
         assertTrue(names.contains("greet"), "Should contain greet tool");
-        assertEquals(2, names.size());
     }
 
     @Test
@@ -82,5 +105,32 @@ class AppTest {
         assertFalse(result.isError());
         var text = ((McpSchema.TextContent) result.content().getFirst()).text();
         assertEquals("Hello, Alice! Welcome to TFL.", text);
+    }
+
+    // --- line_status ---
+
+    @Test
+    void listToolsContainsLineStatus() {
+        var result = client.listTools();
+        var names = result.tools().stream().map(McpSchema.Tool::name).toList();
+        assertTrue(names.contains("line_status"), "Should contain line_status tool");
+    }
+
+    @Test
+    void lineStatusReturnsStatusForCentralLine() {
+        var result = client.callTool(new McpSchema.CallToolRequest("line_status", Map.of("lines", "central")));
+        assertFalse(result.isError());
+        var text = ((McpSchema.TextContent) result.content().getFirst()).text();
+        assertTrue(text.toLowerCase().contains("central"), "Response should mention Central line");
+        assertTrue(text.contains("Good Service"), "Response should contain the status");
+    }
+
+    @Test
+    void lineStatusAcceptsMultipleLines() {
+        var result = client.callTool(new McpSchema.CallToolRequest("line_status", Map.of("lines", "central,victoria")));
+        assertFalse(result.isError());
+        var text = ((McpSchema.TextContent) result.content().getFirst()).text();
+        assertTrue(text.toLowerCase().contains("central"), "Response should mention Central line");
+        assertTrue(text.toLowerCase().contains("victoria"), "Response should mention Victoria line");
     }
 }


### PR DESCRIPTION
## Summary

Adds the first real TfL API integration tool (`line_status`) to the MCP server, enabling AI assistants to query the current status of London transport lines. This includes HTTP client setup, JSON parsing, and comprehensive integration tests using WireMock.

## Key Changes

- **New `line_status` tool**: Accepts comma-separated line IDs (e.g., "central,victoria") and returns formatted status descriptions with disruption reasons
- **HTTP client infrastructure**: Added Jackson ObjectMapper and Java 11+ HttpClient for TfL API calls; respects optional `TFL_APP_KEY` environment variable for higher rate limits
- **Configurable TfL base URL**: Added second constructor parameter to support testing against stubbed endpoints
- **WireMock test stubs**: Integration tests now mock TfL API responses instead of making real network calls
- **Documentation**: Added `AGENTS.md` (architecture & TfL API reference) and `TODO.md` (feature backlog); updated README with configuration and tool descriptions

## Implementation Details

- `fetchLineStatus()` parses TfL JSON responses and formats output as human-readable line status summaries (e.g., "Central: Good Service\nVictoria: Minor Delays — Earlier signal failure")
- Tests verify single-line and multi-line queries; error handling returns `isError=true` with exception message
- Removed assertion on exact tool count in `listToolsReturnsEchoAndGreet` test to allow future tool additions without test churn
- All HTTP calls to TfL include the API key as a query parameter if `TFL_APP_KEY` is set

## Testing

- 3 new integration tests cover the `line_status` tool (presence, single line, multiple lines)
- WireMock stubs handle `/Line/{ids}/Status` requests; no real TfL API calls during test runs
- Full test suite passes: `./gradlew test`

https://claude.ai/code/session_012Rd25opBiz52yjbtK7XXHc