### PR TITLE
Add stop search tool and refactor TfL API authentication

### DIFF
--- a/src/main/java/com/aon/tfl/App.java
+++ b/src/main/java/com/aon/tfl/App.java
@@ -24,6 +24,7 @@ import java.util.Map;
 public class App {
 
     private static final String TFL_APP_KEY = System.getenv("TFL_APP_KEY");
+    private static final String TFL_APP_ID = System.getenv("TFL_APP_ID");
     private static final HttpClient HTTP = HttpClient.newHttpClient();
     private static final ObjectMapper JSON = new ObjectMapper();
 
@@ -101,6 +102,29 @@ public class App {
                         })
                 .toolCall(
                         McpSchema.Tool.builder()
+                                .name("stop_search")
+                                .description("Search for TfL stops by name or query string")
+                                .inputSchema(new McpSchema.JsonSchema(
+                                        "object",
+                                        Map.of("query", Map.of("type", "string", "description", "Stop name or search term, e.g. oxford")),
+                                        List.of("query"),
+                                        null, null, null))
+                                .build(),
+                        (exchange, request) -> {
+                            String query = request.arguments().get("query").toString();
+                            try {
+                                return McpSchema.CallToolResult.builder()
+                                        .addTextContent(fetchStopSearch(query))
+                                        .build();
+                            } catch (Exception e) {
+                                return McpSchema.CallToolResult.builder()
+                                        .addTextContent("Error searching stops: " + e.getMessage())
+                                        .isError(true)
+                                        .build();
+                            }
+                        })
+                .toolCall(
+                        McpSchema.Tool.builder()
                                 .name("line_status")
                                 .description("Get the current status of one or more TfL lines (e.g. central, victoria, jubilee)")
                                 .inputSchema(new McpSchema.JsonSchema(
@@ -151,19 +175,37 @@ public class App {
         jetty.stop();
     }
 
-    private String fetchArrivals(String stopId) throws Exception {
-        String url = tflBase + "/StopPoint/" + stopId + "/Arrivals";
-        if (TFL_APP_KEY != null && !TFL_APP_KEY.isBlank()) {
-            url += "?app_key=" + TFL_APP_KEY;
+    private String withAuth(String url) {
+        var params = new ArrayList<String>();
+        if (TFL_APP_ID != null && !TFL_APP_ID.isBlank()) params.add("app_id=" + TFL_APP_ID);
+        if (TFL_APP_KEY != null && !TFL_APP_KEY.isBlank()) params.add("app_key=" + TFL_APP_KEY);
+        if (params.isEmpty()) return url;
+        return url + "?" + String.join("&", params);
+    }
+
+    private String fetchStopSearch(String query) throws Exception {
+        String url = withAuth(tflBase + "/StopPoint/Search/" + query);
+        var request = HttpRequest.newBuilder(URI.create(url)).GET().build();
+        var response = HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+        JsonNode root = JSON.readTree(response.body());
+
+        var sb = new StringBuilder();
+        for (JsonNode match : root.path("matches")) {
+            String id = match.path("id").asText();
+            String name = match.path("name").asText();
+            sb.append(id).append(" — ").append(name).append("\n");
         }
+        return sb.toString().trim();
+    }
+
+    private String fetchArrivals(String stopId) throws Exception {
+        String url = withAuth(tflBase + "/StopPoint/" + stopId + "/Arrivals");
         var request = HttpRequest.newBuilder(URI.create(url)).GET().build();
         var response = HTTP.send(request, HttpResponse.BodyHandlers.ofString());
         JsonNode root = JSON.readTree(response.body());
 
         var arrivals = new ArrayList<JsonNode>();
-        for (JsonNode arrival : root) {
-            arrivals.add(arrival);
-        }
+        for (JsonNode arrival : root) arrivals.add(arrival);
         arrivals.sort((a, b) -> Integer.compare(
                 a.path("timeToStation").asInt(),
                 b.path("timeToStation").asInt()));
@@ -184,10 +226,7 @@ public class App {
     }
 
     private String fetchLineStatus(String lines) throws Exception {
-        String url = tflBase + "/Line/" + lines + "/Status";
-        if (TFL_APP_KEY != null && !TFL_APP_KEY.isBlank()) {
-            url += "?app_key=" + TFL_APP_KEY;
-        }
+        String url = withAuth(tflBase + "/Line/" + lines + "/Status");
         var request = HttpRequest.newBuilder(URI.create(url)).GET().build();
         var response = HTTP.send(request, HttpResponse.BodyHandlers.ofString());
         JsonNode root = JSON.readTree(response.body());

--- a/src/test/java/com/aon/tfl/AppTest.java
+++ b/src/test/java/com/aon/tfl/AppTest.java
@@ -55,6 +55,18 @@ class AppTest {
                                 ]
                                 """)));
 
+        wireMock.stubFor(get(urlPathMatching("/StopPoint/Search/oxford"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "matches": [
+                                    {"id":"940GZZLUOXC","name":"Oxford Circus Underground Station","lat":51.515,"lon":-0.1416},
+                                    {"id":"490000173RC","name":"Oxford Circus","lat":51.5148,"lon":-0.1418}
+                                  ]
+                                }
+                                """)));
+
         app = new App(0, "http://localhost:" + wireMock.port());
         app.start();
 
@@ -152,6 +164,24 @@ class AppTest {
         assertTrue(text.contains("Central"), "Response should mention the line name");
         assertTrue(text.contains("Epping"), "Response should mention the destination");
         assertTrue(text.contains("2 min") || text.contains("120"), "Response should include time to station");
+    }
+
+    // --- stop_search ---
+
+    @Test
+    void listToolsContainsStopSearch() {
+        var result = client.listTools();
+        var names = result.tools().stream().map(McpSchema.Tool::name).toList();
+        assertTrue(names.contains("stop_search"), "Should contain stop_search tool");
+    }
+
+    @Test
+    void stopSearchReturnsMatchingStops() {
+        var result = client.callTool(new McpSchema.CallToolRequest("stop_search", Map.of("query", "oxford")));
+        assertFalse(result.isError());
+        var text = ((McpSchema.TextContent) result.content().getFirst()).text();
+        assertTrue(text.contains("Oxford Circus"), "Response should mention Oxford Circus");
+        assertTrue(text.contains("940GZZLUOXC"), "Response should include the stop ID");
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR adds a new `stop_search` tool to search for TfL stops by name or query string, and refactors the authentication logic to support both `TFL_APP_ID` and `TFL_APP_KEY` environment variables.

## Key Changes
- **New stop_search tool**: Allows users to search for TfL stops by name (e.g., "oxford") and returns matching stops with their IDs and names
- **Authentication refactoring**: Extracted common URL authentication logic into a new `withAuth()` helper method that supports both `TFL_APP_ID` and `TFL_APP_KEY` parameters
- **Environment variable support**: Added `TFL_APP_ID` environment variable alongside the existing `TFL_APP_KEY`
- **Code cleanup**: Simplified inline array iteration in `fetchArrivals()` method
- **Test coverage**: Added comprehensive tests for the new `stop_search` tool including tool listing and search result validation

## Implementation Details
- The `withAuth()` method builds query parameters dynamically, supporting both authentication credentials when available
- The `fetchStopSearch()` method parses the TfL API response and formats results as "id — name" pairs
- Both `fetchArrivals()` and `fetchLineStatus()` now use the centralized `withAuth()` method for consistency
- The stop search tool includes proper error handling with user-friendly error messages

https://claude.ai/code/session_0118CrpfSdR8CioRp9GRmnaE