### PR TITLE
Add disruptions tool to query TfL service disruptions by mode

### DIFF
--- a/src/main/java/com/aon/tfl/App.java
+++ b/src/main/java/com/aon/tfl/App.java
@@ -125,6 +125,29 @@ public class App {
                         })
                 .toolCall(
                         McpSchema.Tool.builder()
+                                .name("disruptions")
+                                .description("Get current disruptions for one or more TfL modes (e.g. tube, bus, elizabeth-line)")
+                                .inputSchema(new McpSchema.JsonSchema(
+                                        "object",
+                                        Map.of("modes", Map.of("type", "string", "description", "Comma-separated transport modes, e.g. tube,bus")),
+                                        List.of("modes"),
+                                        null, null, null))
+                                .build(),
+                        (exchange, request) -> {
+                            String modes = request.arguments().get("modes").toString();
+                            try {
+                                return McpSchema.CallToolResult.builder()
+                                        .addTextContent(fetchDisruptions(modes))
+                                        .build();
+                            } catch (Exception e) {
+                                return McpSchema.CallToolResult.builder()
+                                        .addTextContent("Error fetching disruptions: " + e.getMessage())
+                                        .isError(true)
+                                        .build();
+                            }
+                        })
+                .toolCall(
+                        McpSchema.Tool.builder()
                                 .name("line_status")
                                 .description("Get the current status of one or more TfL lines (e.g. central, victoria, jubilee)")
                                 .inputSchema(new McpSchema.JsonSchema(
@@ -181,6 +204,21 @@ public class App {
         if (TFL_APP_KEY != null && !TFL_APP_KEY.isBlank()) params.add("app_key=" + TFL_APP_KEY);
         if (params.isEmpty()) return url;
         return url + "?" + String.join("&", params);
+    }
+
+    private String fetchDisruptions(String modes) throws Exception {
+        String url = withAuth(tflBase + "/Line/Mode/" + modes + "/Disruption");
+        var request = HttpRequest.newBuilder(URI.create(url)).GET().build();
+        var response = HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+        JsonNode root = JSON.readTree(response.body());
+
+        var sb = new StringBuilder();
+        for (JsonNode disruption : root) {
+            String lineId = disruption.path("lineId").asText();
+            String description = disruption.path("description").asText();
+            sb.append(lineId).append(": ").append(description).append("\n");
+        }
+        return sb.toString().trim();
     }
 
     private String fetchStopSearch(String query) throws Exception {

--- a/src/test/java/com/aon/tfl/AppTest.java
+++ b/src/test/java/com/aon/tfl/AppTest.java
@@ -67,6 +67,16 @@ class AppTest {
                                 }
                                 """)));
 
+        wireMock.stubFor(get(urlPathMatching("/Line/Mode/tube/Disruption"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                [
+                                  {"lineId":"central","description":"Minor delays due to earlier signal failure near Oxford Circus"},
+                                  {"lineId":"jubilee","description":"Good service"}
+                                ]
+                                """)));
+
         app = new App(0, "http://localhost:" + wireMock.port());
         app.start();
 
@@ -182,6 +192,24 @@ class AppTest {
         var text = ((McpSchema.TextContent) result.content().getFirst()).text();
         assertTrue(text.contains("Oxford Circus"), "Response should mention Oxford Circus");
         assertTrue(text.contains("940GZZLUOXC"), "Response should include the stop ID");
+    }
+
+    // --- disruptions ---
+
+    @Test
+    void listToolsContainsDisruptions() {
+        var result = client.listTools();
+        var names = result.tools().stream().map(McpSchema.Tool::name).toList();
+        assertTrue(names.contains("disruptions"), "Should contain disruptions tool");
+    }
+
+    @Test
+    void disruptionsReturnsDisruptionsByMode() {
+        var result = client.callTool(new McpSchema.CallToolRequest("disruptions", Map.of("modes", "tube")));
+        assertFalse(result.isError());
+        var text = ((McpSchema.TextContent) result.content().getFirst()).text();
+        assertTrue(text.contains("central"), "Response should mention the affected line");
+        assertTrue(text.contains("signal failure") || text.contains("Minor delays"), "Response should include disruption description");
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR adds a new MCP tool called "disruptions" that allows querying current service disruptions for one or more TfL transport modes (e.g., tube, bus, elizabeth-line).

## Key Changes
- **New `disruptions` tool**: Accepts a comma-separated list of transport modes and returns current disruptions affecting those lines
- **New `fetchDisruptions()` method**: Calls the TfL API endpoint `/Line/Mode/{modes}/Disruption` and parses the response to extract line IDs and disruption descriptions
- **Tool registration**: Registered the disruptions tool in the MCP schema with proper input validation (requires "modes" parameter)
- **Error handling**: Gracefully handles API errors and returns error responses to the client
- **Test coverage**: Added comprehensive tests including:
  - Verification that the disruptions tool is listed in available tools
  - Integration test confirming the tool correctly returns disruption data for a given mode
  - Mock API response setup for testing

## Implementation Details
- The tool accepts a "modes" parameter (string) containing comma-separated transport mode names
- Disruption data is formatted as "lineId: description" pairs, one per line
- The implementation follows the same pattern as existing tools (line_status, stop_search) with proper authentication and error handling

https://claude.ai/code/session_01DwmiVwd8BbmcQxiwCNccAL