### PR TITLE
feat: add journey tool (GET /Journey/JourneyResults/{from}/to/{to})

### DIFF
--- a/src/main/java/com/aon/tfl/App.java
+++ b/src/main/java/com/aon/tfl/App.java
@@ -169,6 +169,32 @@ public class App {
                                         .build();
                             }
                         })
+                .toolCall(
+                        McpSchema.Tool.builder()
+                                .name("journey")
+                                .description("Plan a journey between two points using the TfL Journey Planner")
+                                .inputSchema(new McpSchema.JsonSchema(
+                                        "object",
+                                        Map.of(
+                                                "from", Map.of("type", "string", "description", "Origin: NaPTAN ID, postcode, or lat,lon"),
+                                                "to",   Map.of("type", "string", "description", "Destination: NaPTAN ID, postcode, or lat,lon")),
+                                        List.of("from", "to"),
+                                        null, null, null))
+                                .build(),
+                        (exchange, request) -> {
+                            String from = request.arguments().get("from").toString();
+                            String to   = request.arguments().get("to").toString();
+                            try {
+                                return McpSchema.CallToolResult.builder()
+                                        .addTextContent(fetchJourney(from, to))
+                                        .build();
+                            } catch (Exception e) {
+                                return McpSchema.CallToolResult.builder()
+                                        .addTextContent("Error fetching journey: " + e.getMessage())
+                                        .isError(true)
+                                        .build();
+                            }
+                        })
                 .build();
 
         jetty = new Server();
@@ -259,6 +285,27 @@ public class App {
               .append(": ").append(minutes).append(" min");
             if (!platform.isBlank()) sb.append(" (").append(platform).append(")");
             sb.append("\n");
+        }
+        return sb.toString().trim();
+    }
+
+    private String fetchJourney(String from, String to) throws Exception {
+        String url = withAuth(tflBase + "/Journey/JourneyResults/" + from + "/to/" + to);
+        var request = HttpRequest.newBuilder(URI.create(url)).GET().build();
+        var response = HTTP.send(request, HttpResponse.BodyHandlers.ofString());
+        JsonNode root = JSON.readTree(response.body());
+
+        var sb = new StringBuilder();
+        int journeyNum = 1;
+        for (JsonNode journey : root.path("journeys")) {
+            int duration = journey.path("duration").asInt();
+            sb.append("Journey ").append(journeyNum++).append(" (").append(duration).append(" min):\n");
+            for (JsonNode leg : journey.path("legs")) {
+                String summary = leg.path("instruction").path("summary").asText(
+                        leg.path("summary").asText());
+                int legDuration = leg.path("duration").asInt();
+                sb.append("  - ").append(summary).append(" (").append(legDuration).append(" min)\n");
+            }
         }
         return sb.toString().trim();
     }

--- a/src/test/java/com/aon/tfl/AppTest.java
+++ b/src/test/java/com/aon/tfl/AppTest.java
@@ -77,6 +77,41 @@ class AppTest {
                                 ]
                                 """)));
 
+        wireMock.stubFor(get(urlPathMatching("/Journey/JourneyResults/1000123/to/1000456"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                  "journeys": [
+                                    {
+                                      "duration": 25,
+                                      "legs": [
+                                        {
+                                          "summary": "Take Central line to Bank",
+                                          "duration": 10,
+                                          "instruction": {"summary": "Take Central line to Bank"}
+                                        },
+                                        {
+                                          "summary": "Walk to destination",
+                                          "duration": 5,
+                                          "instruction": {"summary": "Walk to destination"}
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "duration": 35,
+                                      "legs": [
+                                        {
+                                          "summary": "Take bus 23 to Liverpool Street",
+                                          "duration": 20,
+                                          "instruction": {"summary": "Take bus 23 to Liverpool Street"}
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                                """)));
+
         app = new App(0, "http://localhost:" + wireMock.port());
         app.start();
 
@@ -219,5 +254,23 @@ class AppTest {
         var text = ((McpSchema.TextContent) result.content().getFirst()).text();
         assertTrue(text.toLowerCase().contains("central"), "Response should mention Central line");
         assertTrue(text.toLowerCase().contains("victoria"), "Response should mention Victoria line");
+    }
+
+    // --- journey ---
+
+    @Test
+    void listToolsContainsJourney() {
+        var result = client.listTools();
+        var names = result.tools().stream().map(McpSchema.Tool::name).toList();
+        assertTrue(names.contains("journey"), "Should contain journey tool");
+    }
+
+    @Test
+    void journeyReturnsPlanBetweenTwoPoints() {
+        var result = client.callTool(new McpSchema.CallToolRequest("journey", Map.of("from", "1000123", "to", "1000456")));
+        assertFalse(result.isError());
+        var text = ((McpSchema.TextContent) result.content().getFirst()).text();
+        assertTrue(text.contains("25") || text.contains("Central"), "Response should include journey details");
+        assertTrue(text.contains("Bank") || text.contains("leg") || text.contains("min"), "Response should include leg summary");
     }
 }


### PR DESCRIPTION
Implements TDD red-green cycle for the journey planner tool.
Stubs WireMock for journey endpoint and adds two tests:
listToolsContainsJourney and journeyReturnsPlanBetweenTwoPoints.

https://claude.ai/code/session_01MgAYas9qF1cbuG1UPptnjG