### PR TITLE
feat: add HTTP/SSE server mode for remote MCP connectors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,14 +22,16 @@ dependencies {
     // JSON parsing for TfL API responses (Jackson 2)
     implementation(libs.jackson.databind)
 
+    // Jetty — hosts the SSE transport for HTTP mode
+    implementation(libs.jetty.server)
+    implementation(libs.jetty.servlet)
+
     // Logging
     implementation(libs.slf4j.api)
     runtimeOnly(libs.log4j.slf4j2.impl)
     runtimeOnly(libs.log4j.core)
 
-    // Testing — Jetty used only to host the SSE transport in tests
-    testImplementation(libs.jetty.server)
-    testImplementation(libs.jetty.servlet)
+    // Testing
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.wiremock)
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/src/contractTest/java/com/tfl/ContractTest.java
+++ b/src/contractTest/java/com/tfl/ContractTest.java
@@ -3,13 +3,7 @@ package com.tfl;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
-import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
-
-import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee10.servlet.ServletHolder;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -32,31 +26,13 @@ import static org.junit.jupiter.api.Assertions.*;
 class ContractTest {
 
     static App app;
-    static Server jetty;
     static McpSyncClient client;
 
     @BeforeAll
     static void setUp() throws Exception {
-        var transportProvider = HttpServletSseServerTransportProvider.builder()
-                .messageEndpoint("/mcp/message")
-                .sseEndpoint("/sse")
-                .build();
+        app = App.startHttp(0, "https://api.tfl.gov.uk");
 
-        app = new App(transportProvider, "https://api.tfl.gov.uk");
-
-        jetty = new Server();
-        ServerConnector connector = new ServerConnector(jetty);
-        connector.setPort(0);
-        jetty.addConnector(connector);
-        ServletContextHandler context = new ServletContextHandler();
-        context.setContextPath("/");
-        context.addServlet(new ServletHolder(transportProvider), "/*");
-        jetty.setHandler(context);
-        jetty.start();
-
-        int port = ((ServerConnector) jetty.getConnectors()[0]).getLocalPort();
-
-        var transport = HttpClientSseClientTransport.builder("http://localhost:" + port)
+        var transport = HttpClientSseClientTransport.builder("http://localhost:" + app.getPort())
                 .sseEndpoint("/sse")
                 .build();
 
@@ -71,7 +47,6 @@ class ContractTest {
     static void tearDown() throws Exception {
         if (client != null) client.close();
         if (app != null) app.stop();
-        if (jetty != null) jetty.stop();
     }
 
     @Test

--- a/src/main/java/com/tfl/App.java
+++ b/src/main/java/com/tfl/App.java
@@ -4,12 +4,18 @@ import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 
 import tools.jackson.databind.json.JsonMapper;
 
@@ -54,6 +60,7 @@ public class App {
 
     private final McpSyncServer mcpServer;
     private final String tflBase;
+    private Server jettyServer;
 
     public App(McpServerTransportProvider transportProvider, String tflBase) {
         this.tflBase = tflBase;
@@ -272,8 +279,41 @@ public class App {
                 .build();
     }
 
+    /**
+     * Start the MCP server in HTTP mode with SSE transport on the given port.
+     * Use port 0 for a dynamically allocated port (retrieve with {@link #getPort()}).
+     */
+    public static App startHttp(int port, String tflBase) throws Exception {
+        var transportProvider = HttpServletSseServerTransportProvider.builder()
+                .messageEndpoint("/mcp/message")
+                .sseEndpoint("/sse")
+                .build();
+
+        var app = new App(transportProvider, tflBase);
+
+        var jetty = new Server();
+        var connector = new ServerConnector(jetty);
+        connector.setPort(port);
+        jetty.addConnector(connector);
+        var context = new ServletContextHandler();
+        context.setContextPath("/");
+        context.addServlet(new ServletHolder(transportProvider), "/*");
+        jetty.setHandler(context);
+        jetty.start();
+
+        app.jettyServer = jetty;
+        return app;
+    }
+
+    /** Returns the HTTP port the server is listening on, or -1 if not in HTTP mode. */
+    public int getPort() {
+        if (jettyServer == null) return -1;
+        return ((ServerConnector) jettyServer.getConnectors()[0]).getLocalPort();
+    }
+
     public void stop() throws Exception {
         mcpServer.closeGracefully();
+        if (jettyServer != null) jettyServer.stop();
     }
 
     private String withAuth(String url) {
@@ -427,10 +467,20 @@ public class App {
     }
 
     public static void main(String[] args) throws Exception {
-        McpJsonMapper jsonMapper = new JacksonMcpJsonMapper(new JsonMapper());
-        var transportProvider = new StdioServerTransportProvider(jsonMapper);
-        var app = new App(transportProvider, "https://api.tfl.gov.uk");
-        log.info("TfL MCP server started (stdio transport)");
+        boolean httpMode = Arrays.asList(args).contains("--http");
+
+        final App app;
+        if (httpMode) {
+            int port = Integer.parseInt(System.getenv().getOrDefault("PORT", "8080"));
+            app = startHttp(port, "https://api.tfl.gov.uk");
+            log.info("TfL MCP server started (HTTP/SSE transport on port {})", app.getPort());
+        } else {
+            McpJsonMapper jsonMapper = new JacksonMcpJsonMapper(new JsonMapper());
+            var transportProvider = new StdioServerTransportProvider(jsonMapper);
+            app = new App(transportProvider, "https://api.tfl.gov.uk");
+            log.info("TfL MCP server started (stdio transport)");
+        }
+
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             try { app.stop(); } catch (Exception ignored) {}
         }));

--- a/src/test/java/com/tfl/AppTest.java
+++ b/src/test/java/com/tfl/AppTest.java
@@ -4,13 +4,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.McpSyncClient;
 import io.modelcontextprotocol.client.transport.HttpClientSseClientTransport;
-import io.modelcontextprotocol.server.transport.HttpServletSseServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
-
-import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
-import org.eclipse.jetty.ee10.servlet.ServletHolder;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -27,7 +21,6 @@ class AppTest {
 
     static WireMockServer wireMock;
     static App app;
-    static Server jetty;
     static McpSyncClient client;
 
     @BeforeAll
@@ -167,26 +160,9 @@ class AppTest {
                                 }
                                 """)));
 
-        var transportProvider = HttpServletSseServerTransportProvider.builder()
-                .messageEndpoint("/mcp/message")
-                .sseEndpoint("/sse")
-                .build();
+        app = App.startHttp(0, "http://localhost:" + wireMock.port());
 
-        app = new App(transportProvider, "http://localhost:" + wireMock.port());
-
-        jetty = new Server();
-        ServerConnector connector = new ServerConnector(jetty);
-        connector.setPort(0);
-        jetty.addConnector(connector);
-        ServletContextHandler context = new ServletContextHandler();
-        context.setContextPath("/");
-        context.addServlet(new ServletHolder(transportProvider), "/*");
-        jetty.setHandler(context);
-        jetty.start();
-
-        int port = ((ServerConnector) jetty.getConnectors()[0]).getLocalPort();
-
-        var transport = HttpClientSseClientTransport.builder("http://localhost:" + port)
+        var transport = HttpClientSseClientTransport.builder("http://localhost:" + app.getPort())
                 .sseEndpoint("/sse")
                 .build();
 
@@ -201,7 +177,6 @@ class AppTest {
     static void tearDown() throws Exception {
         if (client != null) client.close();
         if (app != null) app.stop();
-        if (jetty != null) jetty.stop();
         if (wireMock != null) wireMock.stop();
     }
 


### PR DESCRIPTION
Add App.startHttp(port, tflBase) static factory that spins up an
embedded Jetty server with SSE transport, enabling Claude Code and
other HTTP-based MCP clients to connect remotely.

- Move Jetty from test-only to main dependency
- Add --http CLI flag and PORT env var support to main()
- Add getPort() accessor for dynamic port allocation
- Refactor AppTest and ContractTest to use startHttp() (validates
  the production HTTP code path instead of manual Jetty wiring)

https://claude.ai/code/session_01AHjeF3QJRPGVEqrtHA6nz6