### PR TITLE
fix: replace deprecated gradle-home-cache-cleanup with cache-cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v6
         with:
-          gradle-home-cache-cleanup: true
+          cache-cleanup: always
 
       - run: ./gradlew build
 


### PR DESCRIPTION
The gradle/actions/setup-gradle action renamed this option; the old
boolean flag is deprecated in favour of cache-cleanup: always/on-success/never.

https://claude.ai/code/session_01Qscj8QcZjwg6sbRBktn8tE