### PR TITLE
fix: limit service status to tube mode

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -7,13 +7,13 @@ Names of stops are automatically resolved to NaPTAN IDs dynamically.
 
 ## `service_status` — Service Status
 
-Get the current operational status and disruptions of TfL transport modes.
+Get the current operational status and disruptions for London Underground lines.
 
 **Parameters:**
 
 | Name | Type | Required | Description |
 |------|------|----------|-------------|
-| `modes` | string | Yes | Comma-separated modes, e.g. `tube,bus,dlr` |
+| `modes` | string | Yes | Currently fixed to `tube` |
 
 **Example query:** *"Is the Central line running normally?"*
 

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -45,17 +45,9 @@ const ANNOTATIONS = {
   openWorldHint: true as const,
 };
 
-const SERVICE_STATUS_MODES = [
-  "tube",
-  "bus",
-  "overground",
-  "elizabeth-line",
-  "dlr",
-  "tube,bus",
-  "tube,overground,elizabeth-line,dlr",
-] as const;
+const SERVICE_STATUS_MODES = ["tube"] as const;
 const SERVICE_STATUS_MODES_DESCRIPTION =
-  "Comma-separated TfL modes, e.g. tube,bus,overground,elizabeth-line,dlr";
+  "TfL mode to query. Currently only tube is supported.";
 const SERVICE_STATUS_LOG_SCHEMA = {
   type: "object",
   properties: {

--- a/node/test/contract.test.ts
+++ b/node/test/contract.test.ts
@@ -71,19 +71,6 @@ describe("tools without API key", () => {
     expect(text.toLowerCase()).toContain("central");
   });
 
-  it("service_status accepts multiple modes and returns structured JSON", async () => {
-    const result = await client.callTool({
-      name: "service_status",
-      arguments: { modes: "tube,overground,elizabeth-line,dlr" },
-    });
-    expect(result.isError).toBeFalsy();
-    const structuredContent = (result.content as any[]).find((c: any) => c.type === "resource");
-    expect(structuredContent).toBeDefined();
-    expect(structuredContent.resource.mimeType).toBe("application/json");
-    expect(structuredContent.resource.text).not.toContain("<html");
-    expect(() => JSON.parse(structuredContent.resource.text)).not.toThrow();
-  }, 15000);
-
   it("bike_points", async () => {
     const result = await client.callTool({ name: "bike_points", arguments: {} });
     expect(result.isError).toBeFalsy();

--- a/node/test/server.test.ts
+++ b/node/test/server.test.ts
@@ -48,15 +48,6 @@ const STUBS: Record<string, { status: number; body: any }> = {
       { id: "victoria", name: "Victoria", lineStatuses: [{ statusSeverityDescription: "Minor Delays", reason: "Earlier signal failure" }] },
     ],
   },
-  "/Line/Mode/tube,overground,elizabeth-line,dlr/Status": {
-    status: 200,
-    body: [
-      { id: "central", name: "Central", lineStatuses: [{ statusSeverityDescription: "Good Service", reason: "" }] },
-      { id: "london-overground", name: "London Overground", lineStatuses: [{ statusSeverityDescription: "Good Service", reason: "" }] },
-      { id: "elizabeth", name: "Elizabeth line", lineStatuses: [{ statusSeverityDescription: "Good Service", reason: "" }] },
-      { id: "dlr", name: "DLR", lineStatuses: [{ statusSeverityDescription: "Good Service", reason: "" }] },
-    ],
-  },
   "/Line/Mode/unknown-mode/Status": { status: 400, body: "" },
   "/Line/Meta/Modes": {
     status: 200,
@@ -231,16 +222,8 @@ describe("service_status", () => {
       properties: {
         modes: {
           type: "string",
-          description: "Comma-separated TfL modes, e.g. tube,bus,overground,elizabeth-line,dlr",
-          enum: [
-            "tube",
-            "bus",
-            "overground",
-            "elizabeth-line",
-            "dlr",
-            "tube,bus",
-            "tube,overground,elizabeth-line,dlr",
-          ],
+          description: "TfL mode to query. Currently only tube is supported.",
+          enum: ["tube"],
         },
       },
       required: ["modes"],
@@ -256,15 +239,13 @@ describe("service_status", () => {
   });
 
   it("returns structured JSON for smoke inputs", async () => {
-    for (const modes of ["tube", "tube,overground,elizabeth-line,dlr"]) {
-      const result = await client.callTool({ name: "service_status", arguments: { modes } });
-      expect(result.isError).toBeFalsy();
-      const structuredContent = (result.content as any[]).find((c: any) => c.type === "resource");
-      expect(structuredContent).toBeDefined();
-      expect(structuredContent.resource.mimeType).toBe("application/json");
-      expect(structuredContent.resource.text).not.toContain("<html");
-      expect(() => JSON.parse(structuredContent.resource.text)).not.toThrow();
-    }
+    const result = await client.callTool({ name: "service_status", arguments: { modes: "tube" } });
+    expect(result.isError).toBeFalsy();
+    const structuredContent = (result.content as any[]).find((c: any) => c.type === "resource");
+    expect(structuredContent).toBeDefined();
+    expect(structuredContent.resource.mimeType).toBe("application/json");
+    expect(structuredContent.resource.text).not.toContain("<html");
+    expect(() => JSON.parse(structuredContent.resource.text)).not.toThrow();
   });
 
   it("returns error on 400", async () => {
@@ -272,7 +253,7 @@ describe("service_status", () => {
     expect(result.isError).toBe(true);
     const text = (result.content as any)[0].text;
     expect(text).toContain("Invalid arguments for tool service_status");
-    expect(text).toContain("Invalid option");
+    expect(text).toContain('expected \\"tube\\"');
   });
 });
 

--- a/src/contractTest/java/io/github/oneill9/tfl/ContractTest.java
+++ b/src/contractTest/java/io/github/oneill9/tfl/ContractTest.java
@@ -59,25 +59,6 @@ class ContractTest {
     }
 
     @Test
-    void serviceStatusAcceptsMultipleModes() {
-        var result = client.callTool(new McpSchema.CallToolRequest("service_status",
-                Map.of("modes", "tube,overground,elizabeth-line,dlr")));
-        assertFalse(result.isError(), "service_status should not return an error for multiple modes");
-        var text = ((McpSchema.TextContent) result.content().getFirst()).text();
-        assertFalse(text.isBlank(), "service_status should return a non-empty response");
-
-        var embedded = result.content().stream()
-                .filter(McpSchema.EmbeddedResource.class::isInstance)
-                .map(McpSchema.EmbeddedResource.class::cast)
-                .findFirst()
-                .orElseThrow();
-        var resource = (McpSchema.TextResourceContents) embedded.resource();
-        assertEquals("application/json", resource.mimeType());
-        assertFalse(resource.text().contains("<html"), "Structured data should not be HTML");
-        assertDoesNotThrow(() -> new com.fasterxml.jackson.databind.ObjectMapper().readTree(resource.text()));
-    }
-
-    @Test
     void arrivalsReturnsRealData() {
         var result = client.callTool(new McpSchema.CallToolRequest("arrivals",
                 Map.of("stopName", "Oxford Circus Underground Station")));

--- a/src/main/java/io/github/oneill9/tfl/App.java
+++ b/src/main/java/io/github/oneill9/tfl/App.java
@@ -49,14 +49,7 @@ public class App {
     private static final ObjectMapper JSON = new ObjectMapper();
     private static final String SERVICE_STATUS_UI_URI = "ui://tfl/service-status";
     private static final String MCP_APP_MIME_TYPE = "text/html;profile=mcp-app";
-    private static final List<String> SERVICE_STATUS_MODES = List.of(
-            "tube",
-            "bus",
-            "overground",
-            "elizabeth-line",
-            "dlr",
-            "tube,bus",
-            "tube,overground,elizabeth-line,dlr");
+    private static final List<String> SERVICE_STATUS_MODES = List.of("tube");
 
     private static final String VERSION = loadVersion();
 
@@ -286,7 +279,7 @@ public class App {
     private static McpSchema.JsonSchema serviceStatusSchema() {
         var modes = new LinkedHashMap<String, Object>();
         modes.put("type", "string");
-        modes.put("description", "Comma-separated TfL modes, e.g. tube,bus,overground,elizabeth-line,dlr");
+        modes.put("description", "TfL mode to query. Currently only tube is supported.");
         modes.put("enum", SERVICE_STATUS_MODES);
         return new McpSchema.JsonSchema(
                 "object",

--- a/src/test/java/io/github/oneill9/tfl/AppTest.java
+++ b/src/test/java/io/github/oneill9/tfl/AppTest.java
@@ -39,18 +39,6 @@ class AppTest {
                                 ]
                                 """)));
 
-        wireMock.stubFor(get(urlPathMatching("/Line/Mode/tube,overground,elizabeth-line,dlr/Status"))
-                .willReturn(aResponse()
-                        .withHeader("Content-Type", "application/json")
-                        .withBody("""
-                                [
-                                  {"id":"central","name":"Central","lineStatuses":[{"statusSeverityDescription":"Good Service","reason":""}]},
-                                  {"id":"london-overground","name":"London Overground","lineStatuses":[{"statusSeverityDescription":"Good Service","reason":""}]},
-                                  {"id":"elizabeth","name":"Elizabeth line","lineStatuses":[{"statusSeverityDescription":"Good Service","reason":""}]},
-                                  {"id":"dlr","name":"DLR","lineStatuses":[{"statusSeverityDescription":"Good Service","reason":""}]}
-                                ]
-                                """)));
-
         wireMock.stubFor(get(urlPathMatching("/StopPoint/940GZZLUOXC/Arrivals"))
                 .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json")
@@ -277,16 +265,9 @@ class AppTest {
         @SuppressWarnings("unchecked")
         var modes = (Map<String, Object>) schema.properties().get("modes");
         assertEquals("string", modes.get("type"));
-        assertEquals("Comma-separated TfL modes, e.g. tube,bus,overground,elizabeth-line,dlr",
+        assertEquals("TfL mode to query. Currently only tube is supported.",
                 modes.get("description"));
-        assertEquals(List.of(
-                "tube",
-                "bus",
-                "overground",
-                "elizabeth-line",
-                "dlr",
-                "tube,bus",
-                "tube,overground,elizabeth-line,dlr"), modes.get("enum"));
+        assertEquals(List.of("tube"), modes.get("enum"));
     }
 
     @Test
@@ -342,10 +323,8 @@ class AppTest {
     @Test
     void serviceStatusSmokeInputsReturnStructuredJson() {
         assertStructuredServiceStatusJson("tube");
-        assertStructuredServiceStatusJson("tube,overground,elizabeth-line,dlr");
 
         wireMock.verify(getRequestedFor(urlPathEqualTo("/Line/Mode/tube/Status")));
-        wireMock.verify(getRequestedFor(urlPathEqualTo("/Line/Mode/tube,overground,elizabeth-line,dlr/Status")));
     }
 
     // --- arrivals ---


### PR DESCRIPTION
## Summary
- narrow service_status schema enum to the currently supported tube mode
- remove multi-mode smoke and contract coverage
- update tool docs to describe tube-only service status

## Tests
- ./gradlew test
- cd node && npm run build
- cd node && npm test
- ./gradlew contractTest
- cd node && npm run contractTest

## Runtime verification
- restarted the Java HTTP/SSE MCP server on port 8080
- verified the ngrok endpoint advertises enum ["tube"] and service_status returns text plus structured JSON