### PR TITLE
ci: distinguish Java contract test job

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -9,7 +9,7 @@ on:
     types: [ published ]
 
 jobs:
-  contract-tests:
+  contract-tests-java:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,7 +23,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v6
 
-      - name: Run contract tests
+      - name: Run Java contract tests
         run: ./gradlew contractTest
         env:
           TFL_APP_KEY: ${{ secrets.TFL_APP_KEY }}
@@ -40,7 +40,7 @@ jobs:
           cache: npm
           cache-dependency-path: node/package-lock.json
 
-      - name: Run contract tests
+      - name: Run Node contract tests
         run: cd node && npm ci && npm run build && npm run contractTest
         env:
           TFL_APP_KEY: ${{ secrets.TFL_APP_KEY }}


### PR DESCRIPTION
## Summary
- Rename the GitHub Actions Java contract-test job from contract-tests to contract-tests-java.
- Rename the workflow steps to Run Java contract tests and Run Node contract tests so the Actions UI clearly separates the two implementations.
- Leave the Gradle task name and Java source directory layout unchanged.

## Tests
- Not run: workflow label-only change.